### PR TITLE
Add support for PowerShell test on Windows.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ environment:
   nodejs_version: "6"
 
 test_script:
+  - ps: ./absolute bootstrap_test 2>&1
   - ./absolute lint
   - ./absolute bootstrap_test
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   },
 
   "devDependencies": {
+    "minimatch": "^3.0.2",
     "babel-core": "^6.14.0",
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-es2017": "^6.0.15",
@@ -20,6 +21,7 @@
   },
 
   "dependencies": {
+    "minimatch": "^3.0.2",
     "express": "~4.15.2",
     "body-parser": "~1.16.1"
   },


### PR DESCRIPTION
Introduced Windows test bot in #278 but it does test on CMD only. But some
developer might use PowerShell instead of the legacy CMD. So, we should
support for PowerShell test on Windows.

ISSUE=#139