### PR TITLE
Add push_key.js to .gitignore #357

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ out
 third_party/mongodb
 third_party/node
 database
+client/push/push_key.js
+

--- a/client/push/push_key.js
+++ b/client/push/push_key.js
@@ -1,5 +1,0 @@
-export default {
-  'pushVapidKeys': {
-    'publicKey': ''
-  }
-}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -86,6 +86,12 @@ gulp.task('lint_router', finish => {
 
 gulp.task('push_key', () => {
   generatePushKey();
+  child_process.exec('git update-index --assume-unchanged'
+  + ' ./server/push/push_key.js', error => {
+    if(error) {
+      console.log(`Failed to run update-index for push_key ${error}` );
+      }
+  });
 });
 
 gulp.task('start', () => {

--- a/server/push/push_key.js
+++ b/server/push/push_key.js
@@ -1,7 +1,7 @@
 export default {
   'pushServerKey': 'AAAAuU4aFAY:APA91bHL6gDxgTYMHD7q2hTKD_6GwYOcDhPTjiM14vYWwRwAmkl3rijIRnK-9-NdFvy8hrcXvi8IvBLhEPOUQZxZ2N00roSkH1U3tLX7sOGxzsKkTXHp9R2i-GbmYVkK9yYz0RF_wZfP',
   'pushVapidKeys': {
-    'publicKey': 'BIbiSCvmS679hndNYBB2oqmdMcbNwzS7qvgE0M6JHcPJH-4DiwNX6_F9e61xkIAehs06m2GKVvt71la_QumsZkg',
-    'privateKey': 'm8P4dHj2FhGBFzGNGyvwJZh34IZ1_j-Bs0hJH1W2z8s',
+    'publicKey': '',
+    'privateKey': '',
   },
 };

--- a/server/push/push_key.js
+++ b/server/push/push_key.js
@@ -1,7 +1,7 @@
 export default {
   'pushServerKey': 'AAAAuU4aFAY:APA91bHL6gDxgTYMHD7q2hTKD_6GwYOcDhPTjiM14vYWwRwAmkl3rijIRnK-9-NdFvy8hrcXvi8IvBLhEPOUQZxZ2N00roSkH1U3tLX7sOGxzsKkTXHp9R2i-GbmYVkK9yYz0RF_wZfP',
   'pushVapidKeys': {
-    'publicKey': '',
-    'privateKey': '',
+    'publicKey': 'BIbiSCvmS679hndNYBB2oqmdMcbNwzS7qvgE0M6JHcPJH-4DiwNX6_F9e61xkIAehs06m2GKVvt71la_QumsZkg',
+    'privateKey': 'm8P4dHj2FhGBFzGNGyvwJZh34IZ1_j-Bs0hJH1W2z8s',
   },
 };


### PR DESCRIPTION
- push vapid keys are newly generated and added
    by starting server to push_key.js so file changes.
- add client/push/push_key.js to .gitignore not to commit
- add 'git update-index --assume-unchanged server/push/push_key.js' after generating push keys