### PR TITLE
Create a file 'pr' for issue # 257

### DIFF
--- a/bootstrap/command/pr
+++ b/bootstrap/command/pr
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Absolute Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+# Check for token.
+TOKEN=$(git config --local --get PAT.Token)
+USER_ID=$(git config --local --get PAT.User)
+
+# Upload 'pull-request' on the command-line.
+# Before running this, a new commit must be pushed to your origin repo.
+if [ $1 = 'upload' ]
+then
+	if [ -z $T ]
+	then
+		echo "Only the first attempt require your ID and password."
+		read ID
+		read PW
+		GITHUB_TOKEN=$(curl -X POST -u "$ID:$PW" -d '{"note":"Absolute_Token","scopes":["repo"]}' "https://api.github.com/authorizations" | grep -Pom 1 '"token": "\K[^"]*')
+		git config --local --add PAT.User $ID
+		git config --local --add PAT.Token $GITHUB_TOKEN
+		echo "Token is created. Please run command './absilute pr upload or #num' again."
+	else
+		echo "Please write the title and contents of the pull-request."
+		read TITLE
+		read BODY
+		echo "Enter branch's name about origin/upstream"
+		read BR_O
+		read BR_U
+		curl -X POST -u "$USER_ID:$TOKEN" -d '{"title":"'$TITLE'", "body":"'$BODY'", "head":"'$ID':'$BR_O'","base":"'$BR_U'"}' "https://api.github.com/repos/romandev/absolute/pulls"
+	fi
+
+
+# Cherry-pick specific pull-request on command-line
+else
+	let $1
+	if [ $? == 0 ]
+	then
+		git pull https://github.com/romandev/absolute pull/$1/head:pr-$1
+	fi
+fi

--- a/bootstrap/command/pr
+++ b/bootstrap/command/pr
@@ -16,39 +16,51 @@
 
 
 
-# Check for token.
+# Check for token & current branch.
 TOKEN=$(git config --local --get PAT.Token)
 USER_ID=$(git config --local --get PAT.User)
+BR_O=$(git symbolic-ref --short HEAD)
 
 # Upload 'pull-request' on the command-line.
 # Before running this, a new commit must be pushed to your origin repo.
 if [ $1 = 'upload' ]
 then
-	if [ -z $T ]
+	if [ -z $TOKEN ]
 	then
 		echo "Only the first attempt require your ID and password."
 		read ID
 		read PW
-		GITHUB_TOKEN=$(curl -X POST -u "$ID:$PW" -d '{"note":"Absolute_Token","scopes":["repo"]}' "https://api.github.com/authorizations" | grep -Pom 1 '"token": "\K[^"]*')
-		git config --local --add PAT.User $ID
-		git config --local --add PAT.Token $GITHUB_TOKEN
-		echo "Token is created. Please run command './absilute pr upload or #num' again."
+		GITHUB_TOKEN=$(curl -X POST -u "$ID:$PW" -d '{"note":"Token","scopes":["repo"]}' "https://api.github.com/authorizations" | grep -Pom 1 '"token": "\K[^"]*')
+
+		if [ -z $GITHUB_TOKEN ]
+		then
+			echo "Connection Error"
+		else
+			git config --local --add PAT.User $ID
+			git config --local --add PAT.Token $GITHUB_TOKEN
+			echo "Token is created. Please run command './absilute pr upload or #num' again."
+		fi
 	else
 		echo "Please write the title and contents of the pull-request."
 		read TITLE
 		read BODY
-		echo "Enter branch's name about origin/upstream"
-		read BR_O
+		echo "Enter upstream's branch name"
 		read BR_U
-		curl -X POST -u "$USER_ID:$TOKEN" -d '{"title":"'$TITLE'", "body":"'$BODY'", "head":"'$ID':'$BR_O'","base":"'$BR_U'"}' "https://api.github.com/repos/romandev/absolute/pulls"
+
+		touch curl_data.json
+		echo "{\"title\" : \"$TITLE\",\"body\" : \"$BODY\",
+		  \"head\" : \"$USER_ID:$BR_O\",\"base\" : \"$BR_U\"}" >> curl_data.json
+		curl -g -X POST -u "$USER_ID:$TOKEN" -d '@curl_data.json' "https://api.github.com/repos/romandev/absolute/pulls"
+		rm curl_data.json
 	fi
 
 
 # Cherry-pick specific pull-request on command-line
+elif [ $1 -gt 0 ]
+then
+
+	git pull https://github.com/romandev/absolute pull/$1/head:pr-$1
+
 else
-	let $1
-	if [ $? == 0 ]
-	then
-		git pull https://github.com/romandev/absolute pull/$1/head:pr-$1
-	fi
+	echo "Try again"
 fi


### PR DESCRIPTION
- It enables pull-requst and cherry-pick on the command line.
- This file is located in /bootstrap/command.
- Use cURL to access the Github-API. And I wrote this process in bash script.
- Use personal access token. Inevitably, it must use basic authentication when creating tokens. In other words, PW must be entered. In the future, this token will replace PW. Of course I'm not sure, but at least that's what I've been looking for. I hope we have a better authentication method (no need to enter password).