### PR TITLE
Fix an order of owner list in CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
-# Absolute Project Owners
-* @romandev
+# Order is important; the last matching pattern takes the most precedence.
 
 # There will be a lot of pull requests in each modules but we don't have enough
 # owners for review process. So, we make the following people become temporary
@@ -16,3 +15,6 @@ server/order/* @coconutperm
 
 # Build
 gulpfile.babel.js @nadongguri
+
+# Absolute Project Owners
+* @romandev


### PR DESCRIPTION
In the file, oder is important. The last matching pattern takes the most
precedence. So, before this patch, Global Owner could not have a permission
other module directories. Please see this link[1].

[1] https://help.github.com/articles/about-codeowners/