### PR TITLE
Register applicationServerKey to subscribe

### DIFF
--- a/client/push/push_manager.js
+++ b/client/push/push_manager.js
@@ -30,6 +30,8 @@ export default class Push {
    */
   registerSubscription(subscription) {
     this._subscription = subscription;
+    console.log(`subscription registered :
+      ${JSON.stringify(this._subscription)}`);
   }
 
   /**
@@ -38,4 +40,3 @@ export default class Push {
   getSubscription() {
   }
 }
-

--- a/client/service-worker-manager.js
+++ b/client/service-worker-manager.js
@@ -1,6 +1,22 @@
 import Push from './push/push_manager.js';
+import pushKey from './push/push_key.js'
 
 var push = new Push();
+
+function urlBase64UrlToUint8Array(base64UrlData) {
+  const padding = '='.repeat((4 - base64UrlData.length % 4) % 4);
+  const base64 = (base64UrlData + padding)
+    .replace(/\-/g, '+')
+    .replace(/_/g, '/');
+
+  const rawData = window.atob(base64);
+  const buffer = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    buffer[i] = rawData.charCodeAt(i);
+  }
+  return buffer;
+}
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
@@ -10,8 +26,11 @@ if ('serviceWorker' in navigator) {
         // Push Manager
         if ('PushManager' in window) {
           navigator.serviceWorker.ready.then(function () {
+            const convertedVapidKey =
+            urlBase64UrlToUint8Array(pushKey.pushVapidKeys.publicKey);
             serviceWorkerRegistration.pushManager.subscribe({
               userVisibleOnly: true,
+              applicationServerKey: convertedVapidKey,
             }).then(
               function(pushSubscription) {
                 push.registerSubscription(pushSubscription);
@@ -26,4 +45,3 @@ if ('serviceWorker' in navigator) {
       });
   });
 }
-


### PR DESCRIPTION
- Use vapid public key instead of using sender_id of manifest.json used by gcm