### PR TITLE
Initial codes for typescript.

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2017 The Absolute Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(zino): Should implement this file in typescript. This file will
+// eventually end up with replacing gulpfile.babel.js.
+// Until finishing implementing this file, we can use the following command.
+//   $ ./absolute --gulpfile gulpfile.ts <command>
+console.log('NOT IMPLEMENTED');

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "sass-loader": "^6.0.5",
     "source-map-support": "^0.4.15",
     "style-loader": "^0.18.2",
+    "typescript": "^2.4.2",
     "url-loader": "^0.5.8",
     "webpack": "^2.6.1"
   },


### PR DESCRIPTION
This patch imports TypeScript modules and then introduce gulpfile.ts to replace
gulpfile.babel.js. Until finishing this migration, we can use the following
command to run gulpfile.ts.
  $ ./absolute --gulpfile gulpfile.ts <command>