### PR TITLE
Add npm package 'github_from_cmd'

### DIFF
--- a/bootstrap/absolute.sh
+++ b/bootstrap/absolute.sh
@@ -47,4 +47,8 @@ done
 # TODO(nadongguri): this env vir should be set not here but before gulp command
 export BABEL_CACHE_PATH=$(absolute_path)/.babel-cache.json
 
-gulp $@
+if [ "$1" = 'pr' ] || [ "$1" = 'cp' ]; then
+  node ./node_modules/github_from_cmd/main.js $1 $2
+else
+  gulp $@
+fi

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-config-google": "^0.7.1",
     "eslint-plugin-import": "^2.3.0",
     "file-loader": "^0.11.2",
+    "github_from_cmd":"^1.0.7",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",


### PR DESCRIPTION
[README.MD](https://github.com/GarlicB/github_from_cmd/blob/master/README.md)
Usually the node modules running on the console (such as 'nodemon', 'supervisor') are installed with '-g'. However, it requires user to connect root account in Linux.

So I added my module in package.json for the local install. And For running './absolute pr [branch]' or './absolute cp [num]', The last part of 'absolute.sh' has been modified slightly.