### PR TITLE
Fix Absolute V2 first launch fail issue.

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -16,8 +16,8 @@
 
 import * as gulp from 'gulp';
 import * as nodemon from 'gulp-nodemon';
-import * as tsc from 'gulp-typescript';
 import * as runSequence from 'run-sequence';
+import * as tsc from 'gulp-typescript';
 
 gulp.task('default', () => {
   runSequence('build_server', 'run_server');

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -17,12 +17,15 @@
 import * as gulp from 'gulp';
 import * as nodemon from 'gulp-nodemon';
 import * as tsc from 'gulp-typescript';
+import * as runSequence from 'run-sequence';
 
-gulp.task('default', ['run_server']);
+gulp.task('default', () => {
+  runSequence('build_server', 'run_server');
+});
 
 gulp.task('test', ['build_server']);
 
-gulp.task('run_server', ['build_server'], () => {
+gulp.task('run_server', () => {
   nodemon({
     script: 'out/server.js',
     ignore: 'out/'
@@ -30,7 +33,7 @@ gulp.task('run_server', ['build_server'], () => {
 });
 
 gulp.task('build_server', () => {
-  gulp.src('./server/**/*.ts')
+  return gulp.src('./server/**/*.ts')
     .pipe(tsc({
       target: 'es5',
       noImplicitReturns: true,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@types/express": "^4.0.37",
     "express": "^4.16.1",
     "gulp": "^3.9.1",
+    "run-sequence": "^2.2.0",
     "gulp-nodemon": "^2.2.1",
     "gulp-typescript": "^3.2.2",
     "ts-node": "^3.3.0",


### PR DESCRIPTION
For this issue, I add run-sequence package to package.json file.
```
"run-sequence":"^2.2.0"
```

And then, I modify default task in gulpfile.ts
```
gulp.task('default', () => {
  runSequence('build_server', 'run_server');
});
```

ISSUE=#461