### PR TITLE
Add callback for default task

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -19,8 +19,8 @@ import * as nodemon from 'gulp-nodemon';
 import * as runSequence from 'run-sequence';
 import * as tsc from 'gulp-typescript';
 
-gulp.task('default', () => {
-  runSequence('build_server', 'run_server');
+gulp.task('default', (callback) => {
+  runSequence('build_server', 'run_server', callback);
 });
 
 gulp.task('test', ['build_server']);


### PR DESCRIPTION
We do not set callback for default task.
default task is finished after call run sequence.

For this reason, we get task logs like below:
```
[03:50:01] Starting 'default'...
[03:50:01] Starting 'build_server'...
[03:50:01] Finished 'default' after 28 ms
[03:50:02] Finished 'build_server' after 861 ms
[03:50:02] Starting 'run_server'...
[03:50:02] Finished 'run_server' after 51 ms
```

So I add callback function for waiting for run_server task
After this PR, we can see task logs like below:
```
[03:50:01] Starting 'default'...
[03:50:01] Starting 'build_server'...
[03:50:02] Finished 'build_server' after 861 ms
[03:50:02] Starting 'run_server'...
[03:50:02] Finished 'run_server' after 51 ms
[03:50:01] Finished 'default' after 912 ms
```

Please refer to
[run sequence](https://www.npmjs.com/package/run-sequence)

ISSUE=NONE