### PR TITLE
Apply tslint for linting TypeScript.

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -17,10 +17,32 @@
 import * as gulp from 'gulp';
 import * as nodemon from 'gulp-nodemon';
 import * as runSequence from 'run-sequence';
+import tslint from 'gulp-tslint';
 import * as tsc from 'gulp-typescript';
 
 gulp.task('default', (callback) => {
   runSequence('build_server', 'run_server', callback);
+});
+
+gulp.task('lint', () => {
+  gulp.src('./server/**/*.ts')
+    .pipe(tslint({
+      formatter: 'codeFrame'
+    }))
+    .pipe(tslint.report({
+      summarizeFailureOutput: true
+    }));
+});
+
+gulp.task('lint:fix', () => {
+  gulp.src('./server/**/*.ts')
+    .pipe(tslint({
+      fix: true,
+      formatter: 'codeFrame'
+    }))
+    .pipe(tslint.report({
+      summarizeFailureOutput: true
+    }));
 });
 
 gulp.task('test', ['build_server']);

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
     "@types/express": "^4.0.37",
     "express": "^4.16.1",
     "gulp": "^3.9.1",
-    "run-sequence": "^2.2.0",
     "gulp-nodemon": "^2.2.1",
+    "gulp-tslint": "^8.1.2",
     "gulp-typescript": "^3.2.2",
+    "run-sequence": "^2.2.0",
     "ts-node": "^3.3.0",
+    "tslint": "^5.7.0",
+    "tslint-microsoft-contrib": "^5.0.1",
     "typescript": "^2.5.3"
   }
 }

--- a/server/base/application.ts
+++ b/server/base/application.ts
@@ -19,17 +19,17 @@ import * as express from 'express';
 export default class Application {
   private static app_: express.Application = express();
 
-  static async start() {
+  public static async start() {
     await import('../example/example.router');
     this.app_.listen(8090);
   }
 
-  static route(url: string) {
-    let app: express.Application = this.app_;
+  public static route(url: string) {
+    const app: express.Application = this.app_;
 
-    return function <T>(routerClass: { new(...args: any[]): T}): void {
-      let routerHandler: any = new routerClass();
-      let router = express.Router();
+    return function <T>(routerClass: { new(...args: {}[]): T}): void {
+      const routerHandler: any = new routerClass();
+      const router = express.Router();
 
       if (routerHandler.post)
         router.post(url, routerHandler.post);
@@ -44,6 +44,6 @@ export default class Application {
         router.delete(url, routerHandler.delete);
 
       app.use('/', router);
-    }
+    };
   }
 }

--- a/server/example/example.router.ts
+++ b/server/example/example.router.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import Application from '../base/application';
 import * as express from 'express';
+import Application from '../base/application';
 
 @Application.route('/hello')
 export default class Test {
-  get(request: express.Request, response: express.Response) {
+  public get(request: express.Request, response: express.Response) {
     response.send('world');
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tslint-microsoft-contrib"
+}


### PR DESCRIPTION
After this patch, we can use the following commands:
  $ ./absolute lint
  $ ./absolute lint:fix

Also, this patch is fixing some lint errors that we can fix using
'lint:fix' automatically. On the other hand, the unresolved errors will
be fixed step by step in follow-up patch. Once resoloving the remaining
errors, we will be able to integrate the lint test with CI tools.

ISSUE=#465