### PR TITLE
Separate configuration for TypeScript from gulpfile.ts

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -50,21 +50,14 @@ gulp.task('test', ['build_server']);
 gulp.task('run_server', () => {
   nodemon({
     script: 'out/server.js',
-    ignore: 'out/'
+    ignore: ['out/']
   });
 });
 
+const tsProject = tsc.createProject('tsconfig.json');
 gulp.task('build_server', () => {
-  return gulp.src('./server/**/*.ts')
-    .pipe(tsc({
-      target: 'es5',
-      noImplicitReturns: true,
-      noImplicitAny: true,
-      preserveConstEnums: true,
-      sourceMap: true,
-      lib: ['es2015'],
-      experimentalDecorators: true,
-    }))
+  return tsProject.src()
+    .pipe(tsProject())
     .js
     .pipe(gulp.dest('out/'));
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "devDependencies": {
     "@types/express": "^4.0.37",
+    "@types/gulp": "^3.8.33",
+    "@types/gulp-nodemon": "0.0.30",
+    "@types/run-sequence": "0.0.29",
     "express": "^4.16.1",
     "gulp": "^3.9.1",
     "gulp-nodemon": "^2.2.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "target": "es5",
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "lib": ["es2015"],
+    "experimentalDecorators": true
+  },
+  "include": [
+    "server/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Currently, the configuration is hardcoded in gulpfile.ts. It's not bad
but one problem is that the configuration doesn't apply to gulpfile.ts.

ISSUE=none