### PR TITLE
Introduce jest for module unit tests.

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -18,6 +18,7 @@ import * as gulp from 'gulp';
 import * as nodemon from 'gulp-nodemon';
 import * as runSequence from 'run-sequence';
 import tslint from 'gulp-tslint';
+import * as shell from 'gulp-shell';
 import * as tsc from 'gulp-typescript';
 
 gulp.task('default', (callback) => {
@@ -45,7 +46,7 @@ gulp.task('lint:fix', () => {
     }));
 });
 
-gulp.task('test', ['build_server']);
+gulp.task('test', shell.task('jest'));
 
 gulp.task('run_server', () => {
   nodemon({

--- a/package.json
+++ b/package.json
@@ -3,16 +3,40 @@
     "@types/express": "^4.0.37",
     "@types/gulp": "^3.8.33",
     "@types/gulp-nodemon": "0.0.30",
+    "@types/gulp-shell": "0.0.30",
+    "@types/jest": "^21.1.1",
+    "@types/request": "^2.0.3",
     "@types/run-sequence": "0.0.29",
+    "@types/supertest": "^2.0.3",
     "express": "^4.16.1",
     "gulp": "^3.9.1",
     "gulp-nodemon": "^2.2.1",
+    "gulp-shell": "^0.6.3",
     "gulp-tslint": "^8.1.2",
     "gulp-typescript": "^3.2.2",
+    "jest": "^21.2.1",
+    "request": "^2.83.0",
     "run-sequence": "^2.2.0",
+    "supertest": "^3.0.0",
+    "ts-jest": "^21.0.1",
     "ts-node": "^3.3.0",
     "tslint": "^5.7.0",
     "tslint-microsoft-contrib": "^5.0.1",
     "typescript": "^2.5.3"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "jsx",
+      "ts",
+      "tsx"
+    ],
+    "testMatch": [
+      "**/*.test.(ts|tsx)"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    }
   }
 }

--- a/server/base/application.ts
+++ b/server/base/application.ts
@@ -24,6 +24,11 @@ export default class Application {
     this.app_.listen(8090);
   }
 
+  public static async startForTesting(): Promise<express.Application> {
+    await import('../example/example.router');
+    return this.app_;
+  }
+
   public static route(url: string) {
     const app: express.Application = this.app_;
 

--- a/server/example/example.test.ts
+++ b/server/example/example.test.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2017 The Absolute Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import * as express from 'express';
-import Application from '../base/application';
+import {} from 'jest';
+import * as supertest from 'supertest';
+import application from '../base/application';
 
-@Application.route('/example')
-export default class Test {
-  public get(request: express.Request, response: express.Response) {
-    response.send('hello world');
-  }
-}
+test('GET /example', async() => {
+  const request: {} = supertest(await application.startForTesting());
+  const response: {} = await request.get('/example');
+  expect(response.statusCode).toBe(200);
+  expect(response.text).toBe('hello world');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,13 @@
     "noImplicitAny": true,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "lib": ["es2015"],
+    "lib": ["es2015", "dom"],
     "experimentalDecorators": true
   },
   "include": [
     "server/**/*.ts"
+  ],
+  "exclude": [
+    "server/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
In Absolute v2, one of the most important things is unit test. So, we
introduce jest for module unit tests. After this patch, we can run test
as follows:
  $ ./absolute test

Also, this change is adding an example test in server/example/.

ISSUE=none