### PR TITLE
Add client path and web app manifest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 # Please keep your name in alphabetical order.
 
 Akshaj Verma <akshajverma7@gmail.com>
+Bokyung Kwon <elliebkwon@gmail.com>
 Byungkwon Ko <gogag2@gmail.com>
 Changsoo Lee <sollcs.star@gmail.com>
 Daehyun Sung <jimmysung201@gmail.com>

--- a/client/index.html
+++ b/client/index.html
@@ -18,8 +18,4 @@
 <head>
   <link rel="manifest" href="./manifest.json">
 </head>
-<body>
-  <div id="root"></div>
-  <script src="bundle_type.js"></script>
-</body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!--
+ Copyright (c) 2017 The Absolute Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http:www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--!>
+<html>
+<head>
+  <link rel="manifest" href="./manifest.json">
+</head>
+<body>
+  <div id="root"></div>
+  <script src="bundle_type.js"></script>
+</body>
+</html>

--- a/client/manifest.json
+++ b/client/manifest.json
@@ -1,0 +1,8 @@
+{
+  "short_name": "Absolute",
+  "name": "Absolute",
+  "display": "standalone",
+  "theme_color": "#ECEFF1",
+  "background_color": "#ECEFF1",
+  "start_url": "index.html?launcher=true"
+}

--- a/server/base/application.test.ts
+++ b/server/base/application.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017 The Absolute Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {} from 'jest';
+import * as supertest from 'supertest';
+import {Application} from '../base/application';
+
+test('GET /', async() => {
+  const request: {} = supertest(await Application.START_FOR_TESTING());
+  const response: {} = await request.get('/');
+  expect(response.statusCode).toBe(200);
+  expect(response.text).toBe('hello world');
+});

--- a/server/base/application.test.ts
+++ b/server/base/application.test.ts
@@ -22,5 +22,4 @@ test('GET /', async() => {
   const request: {} = supertest(await Application.START_FOR_TESTING());
   const response: {} = await request.get('/');
   expect(response.statusCode).toBe(200);
-  expect(response.text).toBe('hello world');
 });

--- a/server/base/application.ts
+++ b/server/base/application.ts
@@ -15,12 +15,14 @@
  */
 
 import * as express from 'express';
+import * as path from 'path';
 
 export class Application {
   private static app: express.Application = express();
 
   public static async START(): Promise<void> {
     await import('../example/example.router');
+    this.app.use(express.static(path.join(__dirname, '../../client')));
     this.app.listen(8090);
   }
 

--- a/server/base/application.ts
+++ b/server/base/application.ts
@@ -28,7 +28,7 @@ export class Application {
 
   public static async START_FOR_TESTING(): Promise<express.Application> {
     await import('../example/example.router');
-
+    this.app.use(express.static(path.join(__dirname, '../../client')));
     return this.app;
   }
 


### PR DESCRIPTION
- I added client path and index.html / manifest.json files.
- Manifest info can check through below url after run server :
`http://127.0.0.1:8090/manifest.json`
- But currently manifest has minimal information only 
`eg. no launcher image, no gcm_sender_id...`
- Web app will not installed yet because that without service worker. 

ISSUE=#469