### PR TITLE
Fix a build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitReturns": true,
     "preserveConstEnums": true,
     "sourceMap": true,
+    "skipLibCheck": true,
     "target": "es5"
   },
   "exclude": [


### PR DESCRIPTION
Sometime build error occurs as follows:
An async function or method must return a 'Promise'. Make sure you have
a declaration for 'Promise' or include 'ES2015' in your `--lib` option.

ISSUE=none