### PR TITLE
Enable lint test by default in Travis and AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,4 +9,4 @@ branches:
     - master
 
 test_script:
-  - absolute test
+  - absolute lint && absolute test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - ./absolute node -v
 
 script:
-  - ./absolute test
+  - ./absolute lint && ./absolute test

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -52,8 +52,9 @@ gulp.task('lint:fix', () => {
 gulp.task('test', ['webpack'], runCommand('jest'));
 
 gulp.task('run_server', () => {
+  process.env.NODE_PATH = "out/";
   nodemon({
-    script: 'out/server.js',
+    script: 'out/server/server.js',
     ignore: ['out/']
   });
 });
@@ -73,7 +74,7 @@ gulp.task('build_server', () => {
   return tsProject.src()
     .pipe(tsProject())
     .js
-    .pipe(gulp.dest('out/'));
+    .pipe(gulp.dest('out/server/'));
 });
 
 const mongodb_path = './third_party/mongodb';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "webpack-stream": "^4.0.0"
   },
   "jest": {
+    "moduleDirectories": [
+      ".",
+      "node_modules"
+    ],
     "moduleFileExtensions": [
       "js",
       "json",

--- a/server/base/application.test.ts
+++ b/server/base/application.test.ts
@@ -15,8 +15,8 @@
  */
 
 import {} from 'jest';
+import {Application} from 'server/base/application';
 import * as supertest from 'supertest';
-import {Application} from '../base/application';
 
 test('GET /', async() => {
   const request: {} = supertest(await Application.START_FOR_TESTING());

--- a/server/base/application.ts
+++ b/server/base/application.ts
@@ -17,6 +17,9 @@
 import * as express from 'express';
 import * as path from 'path';
 
+/**
+ * Application
+ */
 export class Application {
   private static app: express.Application = express();
 
@@ -29,13 +32,15 @@ export class Application {
   public static async START_FOR_TESTING(): Promise<express.Application> {
     await import('../example/example.router');
     this.app.use(express.static(path.join(__dirname, '../../out/client')));
+
     return this.app;
   }
 
-  public static ROUTE(url: string) {
+  public static ROUTE(url: string): Function {
     const app: express.Application = this.app;
 
     return <T>(routerClass: { new(...args: {}[]): T}): void => {
+      // tslint:disable-next-line
       const routerHandler: any = new routerClass();
       const router: express.Router = express.Router();
 

--- a/server/example/example.router.ts
+++ b/server/example/example.router.ts
@@ -15,10 +15,13 @@
  */
 
 import * as express from 'express';
-import {Application} from '../base/application';
+import {Application} from 'server/base/application';
 
+/**
+ * ExampleRouter
+ */
 @Application.ROUTE('/example')
-export class Test {
+export class ExampleRouter {
   public get(request: express.Request, response: express.Response): void {
     response.send('hello world');
   }

--- a/server/example/example.test.ts
+++ b/server/example/example.test.ts
@@ -15,8 +15,8 @@
  */
 
 import {} from 'jest';
+import {Application} from 'server/base/application';
 import * as supertest from 'supertest';
-import {Application} from '../base/application';
 
 test('GET /example', async() => {
   const request: {} = supertest(await Application.START_FOR_TESTING());

--- a/server/server.ts
+++ b/server/server.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {Application} from './base/application';
+import {Application} from 'server/base/application';
 
 Application.START();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
+    "baseUrl": ".",
     "experimentalDecorators": true,
     "lib": ["webworker", "es6", "scripthost"],
     "noImplicitAny": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,9 @@
 {
-  "extends": "tslint-microsoft-contrib"
+  "extends": "tslint-microsoft-contrib",
+  "rules": {
+    "export-name": false,
+    "no-backbone-get-set-outside-model": false,
+    "no-reserved-keywords": false,
+    "no-stateless-class": false
+  }
 }


### PR DESCRIPTION
This change fixes all lint errors in the current implementation and then
enable lint test by default in Travis and AppVeyor to prevent unexpected
behaviors and errors.

ISSUE=#467