### PR TITLE
Revert "Upgrade Node.js (v6.9.5 -> v8.9.1) (#520)"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,7 +25,6 @@ Jaeseok Yoon <yjaeseok@gmail.com>
 Jinho Bang <zino@chromium.org>
 Jongheon Kim <sapzape@gmail.com>
 Taeyun Kim <twhy.kim@gmail.com>
-Taxoo Kim <taxookim@gmail.com>
 Umar Faruk <umar97faruk@gmail.com>
 Wuseok Jang <rufia00@gmail.com>
 Yeonsu Kim <yeonsuyam@gmail.com>

--- a/bootstrap/absolute.sh
+++ b/bootstrap/absolute.sh
@@ -31,10 +31,8 @@ set_path_env $(absolute_path)/node_modules/.bin
 sync_node
 sync_mongodb
 
-# NPM install or update
-if [ ! -f .pkg_timestamp ]; then
-  npm install && > .pkg_timestamp
-elif [ package.json -nt .pkg_timestamp ]; then
+# NPM update
+if [ ! -f .pkg_timestamp ] || [ package.json -nt .pkg_timestamp ]; then
   npm update && > .pkg_timestamp
 fi
 

--- a/bootstrap/common/sync_third_party.sh
+++ b/bootstrap/common/sync_third_party.sh
@@ -19,14 +19,14 @@
 
 function sync_node() {
   local target_path="./third_party/node"
-  local base_url="https://nodejs.org/dist/v8.9.1"
+  local base_url="https://nodejs.org/dist/v6.9.5"
 
   case $(get_platform_name) in
-    windows_x86) local target_url="/node-v8.9.1-win-x86.zip" ;;
-    windows_x86_64) local target_url="/node-v8.9.1-win-x64.zip" ;;
-    linux_x86) local target_url="/node-v8.9.1-linux-x86.tar.gz" ;;
-    linux_x86_64) local target_url="/node-v8.9.1-linux-x64.tar.gz" ;;
-    darwin_x86_64) local target_url="/node-v8.9.1-darwin-x64.tar.gz" ;;
+    windows_x86) local target_url="/node-v6.9.5-win-x86.zip" ;;
+    windows_x86_64) local target_url="/node-v6.9.5-win-x64.zip" ;;
+    linux_x86) local target_url="/node-v6.9.5-linux-x86.tar.gz" ;;
+    linux_x86_64) local target_url="/node-v6.9.5-linux-x64.tar.gz" ;;
+    darwin_x86_64) local target_url="/node-v6.9.5-darwin-x64.tar.gz" ;;
   esac
 
   sync_third_party $base_url$target_url $target_path


### PR DESCRIPTION
This reverts commit aecd7a943e0360db223438109d40cc9182bd7d06.

Revert reasons:
  The change breaks AppVeyor build.

ISSUE=#518,#531