### PR TITLE
Handle errors about third party download and extract

### DIFF
--- a/bootstrap/common/sync_third_party.sh
+++ b/bootstrap/common/sync_third_party.sh
@@ -29,16 +29,7 @@ function sync_node() {
     darwin_x86_64) local target_url="/node-v6.9.5-darwin-x64.tar.gz" ;;
   esac
 
-  sync_third_party $base_url$target_url $target_path
-
-  local result=$?
-  if [ $result -eq 2 ]; then
-    error_log "node download fail"
-    exit
-  elif [ $result -eq 3 ]; then
-    error_log "node extract fail"
-    exit
-  fi
+  sync_third_party $base_url$target_url $target_path || exit
 }
 
 function sync_mongodb() {
@@ -53,17 +44,7 @@ function sync_mongodb() {
     darwin_x86_64) local target_url="/osx/mongodb-osx-x86_64-3.2.12.tgz" ;;
   esac
 
-  sync_third_party $base_url$target_url $target_path
-
-  local result=$?
-  if [ $result -eq 2 ]; then
-    error_log "mongodb download fail"
-    exit
-  elif [ $result -eq 3 ]; then
-    error_log "mongodb extract fail"
-    exit
-  fi
-
+  sync_third_party $base_url$target_url $target_path || exit
 }
 
 function sync_third_party() {

--- a/bootstrap/common/sync_third_party.sh
+++ b/bootstrap/common/sync_third_party.sh
@@ -53,7 +53,7 @@ function sync_third_party() {
   local filename=$(basename $url)
 
   if ! needs_sync $url $target_path; then
-    return 1
+    return 0
   fi
 
   if is_windows_platform; then

--- a/bootstrap/common/sync_third_party.sh
+++ b/bootstrap/common/sync_third_party.sh
@@ -31,10 +31,11 @@ function sync_node() {
 
   sync_third_party $base_url$target_url $target_path
 
-  if [ $? -eq 2 ]; then
+  local result=$?
+  if [ $result -eq 2 ]; then
     error_log "node download fail"
     exit
-  elif [ $? -eq 3 ]; then
+  elif [ $result -eq 3 ]; then
     error_log "node extract fail"
     exit
   fi
@@ -54,10 +55,11 @@ function sync_mongodb() {
 
   sync_third_party $base_url$target_url $target_path
 
-  if [ $? -eq 2 ]; then
+  local result=$?
+  if [ $result -eq 2 ]; then
     error_log "mongodb download fail"
     exit
-  elif [ $? -eq 3 ]; then
+  elif [ $result -eq 3 ]; then
     error_log "mongodb extract fail"
     exit
   fi

--- a/bootstrap/common/sync_third_party.sh
+++ b/bootstrap/common/sync_third_party.sh
@@ -30,6 +30,14 @@ function sync_node() {
   esac
 
   sync_third_party $base_url$target_url $target_path
+
+  if [ $? -eq 2 ]; then
+    error_log "node download fail"
+    exit
+  elif [ $? -eq 3 ]; then
+    error_log "node extract fail"
+    exit
+  fi
 }
 
 function sync_mongodb() {
@@ -45,6 +53,15 @@ function sync_mongodb() {
   esac
 
   sync_third_party $base_url$target_url $target_path
+
+  if [ $? -eq 2 ]; then
+    error_log "mongodb download fail"
+    exit
+  elif [ $? -eq 3 ]; then
+    error_log "mongodb extract fail"
+    exit
+  fi
+
 }
 
 function sync_third_party() {

--- a/bootstrap/common/util.sh
+++ b/bootstrap/common/util.sh
@@ -81,3 +81,8 @@ function extract_archive() {
 
   return $?
 }
+
+# Print red color log.
+function error_log() {
+  echo -e "\e[31m$1"
+}

--- a/bootstrap/common/util.sh
+++ b/bootstrap/common/util.sh
@@ -77,6 +77,7 @@ function extract_archive() {
   case $src_path in
     *.tar.gz|*.tgz) tar -xvzf $src_path -C $dest_path > /dev/null 2>&1 ;;
     *.zip) unzip $src_path -d $dest_path > /dev/null 2>&1 ;;
+    *) return 3 ;;
   esac
 
   return $?

--- a/bootstrap/common/util.sh
+++ b/bootstrap/common/util.sh
@@ -33,6 +33,7 @@ function download() {
   local path=${2:-./}
 
   if [ -z "$url" ]; then
+    error_log "download fail - no url"
     return 1
   fi
 
@@ -44,7 +45,12 @@ function download() {
         { curl -LO $url > /dev/null 2>&1; cd - > /dev/null; }
   fi
 
-  return $?
+  if [ $? -ne 0 ]; then
+    error_log "download fail - invalid url or network disconnected"
+    return 2
+  else
+    return 0
+  fi
 }
 
 function has_container_directory() {
@@ -61,10 +67,12 @@ function extract_archive() {
   local dest_path=${2:-./}
 
   if [ -z "$src_path" ]; then
+    error_log "extract fail - no path"
     return 1
   fi
 
   if [ ! -f "$src_path" ]; then
+    error_log "extract fail - invalid path"
     return 2
   fi
 
@@ -77,10 +85,15 @@ function extract_archive() {
   case $src_path in
     *.tar.gz|*.tgz) tar -xvzf $src_path -C $dest_path > /dev/null 2>&1 ;;
     *.zip) unzip $src_path -d $dest_path > /dev/null 2>&1 ;;
-    *) return 3 ;;
+    *) error_log "extract fail - invalid file";return 3 ;;
   esac
 
-  return $?
+  if [ $? -ne 0 ]; then
+    error_log "extract fail - tar or unzip fail"
+    return 4
+  else
+    return 0
+  fi
 }
 
 # Print red color log.

--- a/bootstrap/common/util.sh
+++ b/bootstrap/common/util.sh
@@ -84,5 +84,5 @@ function extract_archive() {
 
 # Print red color log.
 function error_log() {
-  echo -e "\e[31m$1"
+  echo -e "\e[31m$1\e[39m"
 }


### PR DESCRIPTION
If script fail to download node binary, it should stop
and print right error log. This patch do it.
Additionally this patch add one function to print red color error log.

ISSUE=none